### PR TITLE
[mod]change suffix of font files

### DIFF
--- a/chapter-06/07-text-geometry.html
+++ b/chapter-06/07-text-geometry.html
@@ -32,9 +32,9 @@
 
     function loadFonts() {
         var fontLoader = new THREE.FontLoader();
-        fontLoader.load("../assets/fonts/helvetiker_regular.typeface.json", function(helvetiker) {
+        fontLoader.load("../assets/fonts/helvetiker_regular.typeface.js", function(helvetiker) {
             fonts['helvetiker'] = helvetiker;
-            fontLoader.load("../assets/fonts/optimer_regular.typeface.json", function(optimer) {
+            fontLoader.load("../assets/fonts/optimer_regular.typeface.js", function(optimer) {
                 fonts['optimer'] = optimer;
                 init();
             });


### PR DESCRIPTION
I modify the bug that is suffix of font files.
*.json -> *.js

But Three.js say the following message, 

"THREE.FontLoader: typeface.js support is being deprecated. Use typeface.json instead."

So, I thing my modification is temporary.
